### PR TITLE
reset solver properly when program size increases

### DIFF
--- a/src/fastsynth/incremental_prop_learn.h
+++ b/src/fastsynth/incremental_prop_learn.h
@@ -37,6 +37,9 @@ class incremental_prop_learnt : public learnt
   /// Number of counterexamples inserted.
   size_t counterexample_counter;
 
+  /// Counterexample set to synthesise against.
+  std::vector<verify_encodingt::counterexamplet> counterexamples;
+
   /// Initialises message handler and adds the base synthesis problem to the
   /// constraint.
   void init();


### PR DESCRIPTION
When the program size increases, the incremental solver needs to be reset to discard any learnt clauses, and all the counterexamples must be re-added