### PR TITLE
Fix `fastsynth` entry in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .cproject
 .project
 .settings
-fastsynth
+src/fastsynth/fastsynth
 *.d
 *.o
 *.exe


### PR DESCRIPTION
Current .gitignore ignores all changes in `fastsynth` directory.