### PR TITLE
Learner interface

### DIFF
--- a/src/fastsynth/Makefile
+++ b/src/fastsynth/Makefile
@@ -1,4 +1,5 @@
 SRC = fastsynth.cpp verify_solver.cpp cegis.cpp \
+      prop_learn.cpp incremental_prop_learn.cpp \
       synth_encoding.cpp verify_encoding.cpp \
       c_frontend.cpp sygus_frontend.cpp smt2_parser.cpp \
       sygus_parser.cpp

--- a/src/fastsynth/cegis.cpp
+++ b/src/fastsynth/cegis.cpp
@@ -1,4 +1,6 @@
 #include "cegis.h"
+#include "incremental_prop_learn.h"
+#include "prop_learn.h"
 #include "synth_encoding.h"
 #include "verify_encoding.h"
 
@@ -13,16 +15,22 @@ decision_proceduret::resultt cegist::operator()(
     const problemt &problem)
 {
   if(incremental_solving)
-    return incremental_loop(problem);
+  {
+    status() << "** incremental CEGIS" << eom;
+    incremental_prop_learnt learn(*this, ns, problem);
+    return loop(problem, learn);
+  }
   else
-    return non_incremental_loop(problem);
+  {
+    status() << "** non-incremental CEGIS" << eom;
+    prop_learnt learn(*this, ns, problem);
+    return loop(problem, learn);
+  }
 }
 
-decision_proceduret::resultt cegist::non_incremental_loop(
-  const problemt &problem)
+decision_proceduret::resultt cegist::loop(
+  const problemt &problem, learnt &learn)
 {
-  status() << "** non-incremental CEGIS" << eom;
-
   unsigned iteration=0;
 
   std::size_t program_size=1;
@@ -32,41 +40,12 @@ decision_proceduret::resultt cegist::non_incremental_loop(
   {
     iteration++;
     status() << "** CEGIS iteration " << iteration << eom;
-    
+
     status() << "** Synthesis phase" << eom;
 
-    satcheckt synth_satcheck;
-    synth_satcheck.set_message_handler(get_message_handler());
+    learn.set_program_size(program_size);
 
-    bv_pointerst synth_solver(ns, synth_satcheck);
-    synth_solver.set_message_handler(get_message_handler());
-
-    synth_encodingt synth_encoding;
-    synth_encoding.program_size=program_size;
-
-    if(counterexamples.empty())
-    {
-      synth_encoding.suffix="$ce";
-      synth_encoding.constraints.clear();
-
-      add_problem(problem, synth_encoding, synth_solver);
-    }
-    else
-    {
-      std::size_t counter=0;
-      for(const auto &c : counterexamples)
-      {
-        synth_encoding.suffix="$ce"+std::to_string(counter);
-        synth_encoding.constraints.clear();
-        add_counterexample(c, synth_encoding, synth_solver);
-
-        add_problem(problem, synth_encoding, synth_solver);
-
-        counter++;
-      }
-    }
-
-    switch(synth_solver())
+    switch(learn())
     {
     case decision_proceduret::resultt::D_SATISFIABLE: // got candidate
       {
@@ -78,7 +57,7 @@ decision_proceduret::resultt cegist::non_incremental_loop(
         debug() << eom;
         #endif
 
-        expressions=synth_encoding.get_expressions(synth_solver);
+        expressions=learn.get_expressions();
 
         for(auto &e : expressions)
           e.second=simplify_expr(e.second, ns);
@@ -127,175 +106,18 @@ decision_proceduret::resultt cegist::non_incremental_loop(
     {
     case decision_proceduret::resultt::D_SATISFIABLE: // counterexample
       status() << "** Verification failed" << eom;
-      counterexamples.push_back(verify_encoding.get_counterexample(verify_solver));
+      learn.add(verify_encoding.get_counterexample(verify_solver));
       break;
 
     case decision_proceduret::resultt::D_UNSATISFIABLE: // done, got solution
-      status() << "Result obtained with " << iteration << " iteration(s)" << eom;
+      status() << "Result obtained with " << iteration << " iteration(s)"
+               << eom;
       result() << "VERIFICATION SUCCESSFUL" << eom;
       return decision_proceduret::resultt::D_SATISFIABLE;
 
     case decision_proceduret::resultt::D_ERROR:
       return decision_proceduret::resultt::D_ERROR;
     }
-
-  }
-}
-
-decision_proceduret::resultt cegist::incremental_loop(
-  const problemt &problem)
-{
-  status() << "** incremental CEGIS" << eom;
-
-  unsigned iteration=0;
-
-  std::size_t program_size=1;
-  std::size_t counterexample_counter=0;
-
-  // now enter the CEGIS loop
-  while(true)
-  {
-    // we get here whenever we increase the size of the program
-
-    satcheck_no_simplifiert synth_satcheck;
-    synth_satcheck.set_message_handler(get_message_handler());
-
-    bv_pointerst synth_solver(ns, synth_satcheck);
-    synth_solver.set_message_handler(get_message_handler());
-
-    synth_encodingt synth_encoding;
-    synth_encoding.program_size=program_size;
-
-    add_problem(problem, synth_encoding, synth_solver);
-
-    bool verify=false;
-
-    do
-    {
-      iteration++;
-      status() << "** CEGIS iteration " << iteration << eom;
-
-      status() << "** Synthesis phase" << eom;
-
-      switch(synth_solver())
-      {
-      case decision_proceduret::resultt::D_SATISFIABLE: // got candidate
-        {
-          std::map<symbol_exprt, exprt> old_expressions;
-          old_expressions.swap(expressions);
-
-          #if 0
-          synth_solver.print_assignment(debug());
-          debug() << eom;
-          #endif
-
-          expressions=synth_encoding.get_expressions(synth_solver);
-
-          for(auto &e : expressions)
-            e.second=simplify_expr(e.second, ns);
-
-          if(old_expressions==expressions)
-          {
-            error() << "NO PROGRESS MADE" << eom;
-            return decision_proceduret::resultt::D_ERROR;
-          }
-        }
-
-        verify=true;
-        break;
-
-      case decision_proceduret::resultt::D_UNSATISFIABLE: // no candidate
-        if(program_size<max_program_size)
-        {
-          program_size+=1;
-          status() << "Failed to get candidate; "
-                      "increasing program size to " << program_size << eom;
-          verify=false; // do another attempt to synthesize
-          break;
-        }
-
-        error() << "FAILED TO GET CANDIDATE" << eom;
-        return decision_proceduret::resultt::D_UNSATISFIABLE;
-
-      case decision_proceduret::resultt::D_ERROR:
-        return decision_proceduret::resultt::D_ERROR;
-      }
-
-      if(verify)
-      {
-        status() << "** Verification phase" << eom;
-
-        output_expressions(expressions, ns, debug());
-        debug() << eom;
-
-        satcheckt verify_satcheck;
-        verify_satcheck.set_message_handler(get_message_handler());
-
-        bv_pointerst verify_solver(ns, verify_satcheck);
-        verify_solver.set_message_handler(get_message_handler());
-
-        verify_encodingt verify_encoding;
-        verify_encoding.expressions=expressions;
-
-        add_problem(problem, verify_encoding, verify_solver);
-
-        switch(verify_solver())
-        {
-        case decision_proceduret::resultt::D_SATISFIABLE: // counterexample
-          {
-            status() << "** Verification failed" << eom;
-
-            auto c=verify_encoding.get_counterexample(verify_solver);
-
-            synth_encoding.constraints.clear();
-
-            synth_encoding.suffix=
-              "$ce"+std::to_string(counterexample_counter);
-
-            add_counterexample(c, synth_encoding, synth_solver);
-            add_problem(problem, synth_encoding, synth_solver);
-
-            counterexample_counter++;
-          }
-          break;
-
-        case decision_proceduret::resultt::D_UNSATISFIABLE: // done, got solution
-          status() << "Result obtained with " << iteration << " iteration(s)" << eom;
-          result() << "VERIFICATION SUCCESSFUL" << eom;
-          return decision_proceduret::resultt::D_SATISFIABLE;
-
-        case decision_proceduret::resultt::D_ERROR:
-          return decision_proceduret::resultt::D_ERROR;
-        }
-      }
-    }
-    while(verify);
-  }
-}
-
-void cegist::add_problem(
-  const problemt &problem,
-  synth_encodingt &encoding,
-  prop_convt &prop_conv)
-{
-  for(const auto &e : problem.side_conditions)
-  {
-    const exprt encoded=encoding(e);
-    debug() << "sc: " << from_expr(ns, "", encoded) << eom;
-    prop_conv.set_to_true(encoded);
-  }
-
-  for(const auto &e : problem.constraints)
-  {
-    const exprt encoded=encoding(e);
-    debug() << "co: " << from_expr(ns, "", encoded) << eom;
-    prop_conv.set_to_true(encoded);
-  }
-
-  for(const auto &c : encoding.constraints)
-  {
-    prop_conv.set_to_true(c);
-    debug() << "ec: " << from_expr(ns, "", c) << eom;
   }
 }
 
@@ -314,22 +136,6 @@ void cegist::add_problem(
   const exprt encoded=encoding(conjunction(problem.constraints));
   debug() << "co: !(" << from_expr(ns, "", encoded) << ')' << eom;
   prop_conv.set_to_false(encoded);
-}
-
-void cegist::add_counterexample(
-  const counterexamplet &ce,
-  synth_encodingt &synth_encoding,
-  prop_convt &prop_conv)
-{
-  for(const auto &it : ce)
-  {
-    const exprt &symbol=it.first;
-    const exprt &value=it.second;
-
-    exprt encoded=synth_encoding(equal_exprt(symbol, value));
-    debug() << "ce: " << from_expr(ns, "", encoded) << eom;
-    prop_conv.set_to_true(encoded);
-  }
 }
 
 void output_expressions(

--- a/src/fastsynth/cegis.h
+++ b/src/fastsynth/cegis.h
@@ -1,3 +1,6 @@
+#ifndef CPROVER_FASTSYNTH_CEGIS_H_
+#define CPROVER_FASTSYNTH_CEGIS_H_
+
 #include <util/std_expr.h>
 #include <util/decision_procedure.h>
 
@@ -22,7 +25,7 @@ public:
   };
 
   decision_proceduret::resultt operator()(const problemt &);
-  
+
   std::map<symbol_exprt, exprt> expressions;
 
   std::size_t max_program_size;
@@ -31,32 +34,11 @@ public:
 protected:
   const namespacet &ns;
 
-  decision_proceduret::resultt incremental_loop(
-    const problemt &);
-
-  decision_proceduret::resultt non_incremental_loop(
-    const problemt &);
-
-  // map symbols to values
-  using counterexamplet=std::map<exprt, exprt>;
-
-  using counterexamplest=std::vector<counterexamplet>;
-
-  counterexamplest counterexamples;
+  decision_proceduret::resultt loop(const problemt &, class learnt &);
 
   void add_problem(
     const problemt &,
     verify_encodingt &,
-    prop_convt &);
-
-  void add_problem(
-    const problemt &,
-    synth_encodingt &,
-    prop_convt &);
-
-  void add_counterexample(
-    const counterexamplet &,
-    synth_encodingt &,
     prop_convt &);
 };
 
@@ -64,3 +46,5 @@ void output_expressions(
   const std::map<symbol_exprt, exprt> &,
   const namespacet &,
   std::ostream &);
+
+#endif /* CPROVER_FASTSYNTH_CEGIS_H_ */

--- a/src/fastsynth/incremental_prop_learn.cpp
+++ b/src/fastsynth/incremental_prop_learn.cpp
@@ -1,0 +1,64 @@
+#include <fastsynth/incremental_prop_learn.h>
+#include <fastsynth/prop_learn.h>
+
+#include <solvers/flattening/bv_pointers.h>
+
+incremental_prop_learnt::incremental_prop_learnt(
+  messaget &msg,
+  const namespacet &ns,
+  const cegist::problemt &problem)
+  : msg(msg),
+    ns(ns),
+    problem(problem),
+    synth_satcheck(new satcheck_no_simplifiert()),
+    synth_solver(new bv_pointerst(ns, *synth_satcheck)),
+    program_size(1u),
+    counterexample_counter(0u)
+{
+  init();
+}
+
+void incremental_prop_learnt::init()
+{
+  synth_encoding.program_size = program_size;
+  synth_satcheck->set_message_handler(msg.get_message_handler());
+  synth_solver->set_message_handler(msg.get_message_handler());
+  add_problem(ns, msg, problem, synth_encoding, *synth_solver);
+}
+
+void incremental_prop_learnt::set_program_size(const size_t program_size)
+{
+  PRECONDITION(program_size >= this->program_size);
+  if(program_size == this->program_size)
+    return;
+  this->program_size = program_size;
+
+  synth_satcheck.reset(new satcheck_minisat_no_simplifiert());
+  synth_solver.reset(new bv_pointerst(ns, *synth_satcheck));
+  synth_encoding = synth_encodingt();
+  counterexample_counter = 0u;
+  init();
+}
+
+decision_proceduret::resultt incremental_prop_learnt::operator()()
+{
+  return (*synth_solver)();
+}
+
+std::map<symbol_exprt, exprt> incremental_prop_learnt::get_expressions() const
+{
+  return synth_encoding.get_expressions(*synth_solver);
+}
+
+void incremental_prop_learnt::add(
+  const verify_encodingt::counterexamplet &counterexample)
+{
+  synth_encoding.constraints.clear();
+
+  synth_encoding.suffix = "$ce" + std::to_string(counterexample_counter);
+
+  add_counterexample(ns, msg, counterexample, synth_encoding, *synth_solver);
+  add_problem(ns, msg, problem, synth_encoding, *synth_solver);
+
+  counterexample_counter++;
+}

--- a/src/fastsynth/incremental_prop_learn.h
+++ b/src/fastsynth/incremental_prop_learn.h
@@ -1,0 +1,67 @@
+#ifndef CPROVER_FASTSYNTH_INCREMENTAL_PROP_LEARN_H_
+#define CPROVER_FASTSYNTH_INCREMENTAL_PROP_LEARN_H_
+
+#include <fastsynth/learn.h>
+#include <fastsynth/cegis.h>
+#include <fastsynth/synth_encoding.h>
+
+#include <solvers/sat/satcheck.h>
+
+#include <memory>
+
+/// Generates a constraint using synth_encodingt and solves it incrementally
+/// using a configurable propt instance.
+class incremental_prop_learnt : public learnt
+{
+  /// Message handler for decision procedure messages.
+  messaget &msg;
+
+  /// Namespace passed on to decision procedure.
+  const namespacet &ns;
+
+  /// Synthesis problem to solve.
+  const cegist::problemt &problem;
+
+  /// Solver instance.
+  std::unique_ptr<satcheck_no_simplifiert> synth_satcheck;
+
+  /// Decision procedure for synthesis logic.
+  std::unique_ptr<class bv_pointerst> synth_solver;
+
+  /// Synthesis learn constraint generator.
+  synth_encodingt synth_encoding;
+
+  /// \see learnt::set_program_size(size_t)
+  size_t program_size;
+
+  /// Number of counterexamples inserted.
+  size_t counterexample_counter;
+
+  /// Initialises message handler and adds the base synthesis problem to the
+  /// constraint.
+  void init();
+
+public:
+  /// Creates an incremental learner.
+  /// \param msg \see msg incremental_prop_learnt::msg
+  /// \param ns \see ns incremental_prop_learnt::ns
+  /// \param problem \see incremental_prop_learnt::problem
+  incremental_prop_learnt(
+    messaget &msg,
+    const namespacet &ns,
+    const cegist::problemt &problem);
+
+  /// \see learnt::set_program_size(size_t)
+  void set_program_size(size_t program_size) override;
+
+  /// \see learnt::operator()()
+  decision_proceduret::resultt operator()() override;
+
+  /// \see learnt::get_expressions()
+  std::map<symbol_exprt, exprt> get_expressions() const override;
+
+  /// \see learnt::add(const verify_encodingt::counterexamplet &counterexample)
+  void add(const verify_encodingt::counterexamplet &counterexample) override;
+};
+
+#endif /* CPROVER_FASTSYNTH_INCREMENTAL_PROP_LEARN_H_ */

--- a/src/fastsynth/learn.h
+++ b/src/fastsynth/learn.h
@@ -1,0 +1,30 @@
+#ifndef CPROVER_FASTSYNTH_LEARN_H_
+#define CPROVER_FASTSYNTH_LEARN_H_
+
+#include <fastsynth/verify_encoding.h>
+
+/// Interface for classes which provide new candidate solutions for
+/// counterexamples.
+class learnt
+{
+public:
+  /// Virtual destructor for defined behaviour.
+  virtual ~learnt() { }
+
+  /// Sets the maximum program size permitted.
+  virtual void set_program_size(size_t program_size) = 0;
+
+  /// Finds a new candidate for the current counterexample set.
+  /// \return \see decision_proceduret::resultt
+  virtual decision_proceduret::resultt operator()() = 0;
+
+  /// Provides the last solution found.
+  /// \return \see verify_encodingt::expressions
+  virtual std::map<symbol_exprt, exprt> get_expressions() const = 0;
+
+  /// Adds an additional counterexample to the search constraint.
+  /// \param counterexample New counterexample.
+  virtual void add(const verify_encodingt::counterexamplet &counterexample) = 0;
+};
+
+#endif /* CPROVER_FASTSYNTH_LEARN_H_ */

--- a/src/fastsynth/prop_learn.cpp
+++ b/src/fastsynth/prop_learn.cpp
@@ -1,0 +1,116 @@
+#include <fastsynth/prop_learn.h>
+#include <fastsynth/synth_encoding.h>
+
+#include <solvers/flattening/bv_pointers.h>
+#include <solvers/sat/satcheck.h>
+
+#include <langapi/language_util.h>
+
+prop_learnt::prop_learnt(
+  messaget &msg,
+  const namespacet &ns,
+  const cegist::problemt &problem)
+  : msg(msg), ns(ns), problem(problem), program_size(1u)
+{
+}
+
+void prop_learnt::set_program_size(const size_t program_size)
+{
+  this->program_size = program_size;
+}
+
+decision_proceduret::resultt prop_learnt::operator()()
+{
+  satcheckt synth_satcheck;
+  synth_satcheck.set_message_handler(msg.get_message_handler());
+
+  bv_pointerst synth_solver(ns, synth_satcheck);
+  synth_solver.set_message_handler(msg.get_message_handler());
+
+  synth_encodingt synth_encoding;
+  synth_encoding.program_size = program_size;
+
+  if(counterexamples.empty())
+  {
+    synth_encoding.suffix = "$ce";
+    synth_encoding.constraints.clear();
+
+    add_problem(ns, msg, problem, synth_encoding, synth_solver);
+  }
+  else
+  {
+    std::size_t counter = 0;
+    for(const auto &c : counterexamples)
+    {
+      synth_encoding.suffix = "$ce" + std::to_string(counter);
+      synth_encoding.constraints.clear();
+      add_counterexample(ns, msg, c, synth_encoding, synth_solver);
+
+      add_problem(ns, msg, problem, synth_encoding, synth_solver);
+
+      counter++;
+    }
+  }
+
+  const decision_proceduret::resultt result(synth_solver());
+  if(decision_proceduret::resultt::D_SATISFIABLE == result)
+    last_solution = synth_encoding.get_expressions(synth_solver);
+
+  return result;
+}
+
+std::map<symbol_exprt, exprt> prop_learnt::get_expressions() const
+{
+  return last_solution;
+}
+
+void prop_learnt::add(const verify_encodingt::counterexamplet &counterexample)
+{
+  counterexamples.emplace_back(counterexample);
+}
+
+void add_counterexample(
+  const namespacet &ns,
+  messaget &msg,
+  const verify_encodingt::counterexamplet &ce,
+  synth_encodingt &synth_encoding,
+  prop_convt &prop_conv)
+{
+  for(const auto &it : ce)
+  {
+    const exprt &symbol = it.first;
+    const exprt &value = it.second;
+
+    exprt encoded = synth_encoding(equal_exprt(symbol, value));
+    msg.debug() << "ce: " << from_expr(ns, "", encoded) << messaget::eom;
+    prop_conv.set_to_true(encoded);
+  }
+}
+
+void add_problem(
+  const namespacet &ns,
+  messaget &msg,
+  const cegist::problemt &problem,
+  synth_encodingt &encoding,
+  prop_convt &prop_conv)
+{
+  for(const exprt &e : problem.side_conditions)
+  {
+    const exprt encoded = encoding(e);
+    msg.debug() << "sc: " << from_expr(ns, "", encoded) << messaget::eom;
+    prop_conv.set_to_true(encoded);
+  }
+
+  for(const auto &e : problem.constraints)
+  {
+    const exprt encoded = encoding(e);
+    msg.debug() << "co: " << from_expr(ns, "", encoded) << messaget::eom;
+    prop_conv.set_to_true(encoded);
+  }
+
+  for(const auto &c : encoding.constraints)
+  {
+    prop_conv.set_to_true(c);
+    msg.debug() << "ec: " << from_expr(ns, "", c) << messaget::eom;
+  }
+}

--- a/src/fastsynth/prop_learn.h
+++ b/src/fastsynth/prop_learn.h
@@ -1,0 +1,79 @@
+#ifndef CPROVER_FASTSYNTH_PROP_LEARN_H_
+#define CPROVER_FASTSYNTH_PROP_LEARN_H_
+
+#include <fastsynth/learn.h>
+#include <fastsynth/cegis.h>
+
+/// Default learner implementation. Generates a constraint using synth_encodingt
+/// and solves it using a configurable propt instance.
+class prop_learnt : public learnt
+{
+  /// Message handler for decision procedure messages.
+  messaget &msg;
+
+  /// Namespace passed on to decision procedure.
+  const namespacet &ns;
+
+  /// Synthesis problem to solve.
+  const cegist::problemt &problem;
+
+  /// \see learnt::set_program_size(size_t)
+  size_t program_size;
+
+  /// Counterexample set to synthesise against.
+  std::vector<verify_encodingt::counterexamplet> counterexamples;
+
+  /// Solution created in the last invocation of prop_learnt::operator()().
+  std::map<symbol_exprt, exprt> last_solution;
+
+public:
+  /// Creates a non-incremental learner.
+  /// \param msg \see msg prop_learnt::msg
+  /// \param ns \see ns prop_learnt::ns
+  /// \param problem \see prop_learnt::problem
+  prop_learnt(
+    messaget &msg,
+    const namespacet &ns,
+    const cegist::problemt &problem);
+
+  /// \see learnt::set_program_size(size_t)
+  void set_program_size(size_t program_size) override;
+
+  /// \see learnt::operator()()
+  decision_proceduret::resultt operator()() override;
+
+  /// \see learnt::get_expressions()
+  std::map<symbol_exprt, exprt> get_expressions() const override;
+
+  /// \see learnt::add(const verify_encodingt::counterexamplet &counterexample)
+  void add(const verify_encodingt::counterexamplet &counterexample) override;
+};
+
+/// Addds an additional counterexample to the constraint.
+/// \param ns Decision procedure namespace.
+/// \param msg Message sink.
+/// \param ce Counterexample to insert.
+/// \param synth_encoding Synthesis encoding to extend by the counterexample.
+/// \param prop_conv Solver instance.
+void add_counterexample(
+  const namespacet &ns,
+  messaget &msg,
+  const verify_encodingt::counterexamplet &ce,
+  synth_encodingt &synth_encoding,
+  prop_convt &prop_conv);
+
+/// Inserts the base synthesis problem without counterexamples into the
+/// constraint.
+/// \param ns Decision procedure namespace.
+/// \param msg Message sink.
+/// \param problem Synthesis problem definition.
+/// \param encoding Synthesis encoding to initialise with the base problem.
+/// \param prop_conv Solver instance.
+void add_problem(
+  const namespacet &ns,
+  messaget &msg,
+  const cegist::problemt &problem,
+  synth_encodingt &encoding,
+  prop_convt &prop_conv);
+
+#endif /* CPROVER_FASTSYNTH_PROP_LEARN_H_ */

--- a/src/fastsynth/synth_encoding.h
+++ b/src/fastsynth/synth_encoding.h
@@ -1,3 +1,6 @@
+#ifndef CPROVER_FASTSYNTH_SYNTH_ENCODING_H_
+#define CPROVER_FASTSYNTH_SYNTH_ENCODING_H_
+
 #include <util/std_expr.h>
 #include <util/decision_procedure.h>
 
@@ -49,7 +52,7 @@ public:
       options.back().sel=symbol_exprt(sel_identifier, bool_typet());
       return options.back();
     }
-    
+
     // generate a constraint for the instruction
     // - for a given word type
     // - for a set of arguments
@@ -128,3 +131,4 @@ protected:
   std::map<symbol_exprt, e_datat> e_data_map;
 };
 
+#endif /* CPROVER_FASTSYNTH_SYNTH_ENCODING_H_ */

--- a/src/fastsynth/verify_encoding.h
+++ b/src/fastsynth/verify_encoding.h
@@ -1,3 +1,6 @@
+#ifndef CPROVER_FASTSYNTH_VERIFY_ENCODING_H_
+#define CPROVER_FASTSYNTH_VERIFY_ENCODING_H_
+
 #include <set>
 
 #include <util/std_expr.h>
@@ -22,3 +25,4 @@ protected:
     const function_application_exprt &e);
 };
 
+#endif /* CPROVER_FASTSYNTH_VERIFY_ENCODING_H_ */


### PR DESCRIPTION
- Introduces a `learnt` interface for learning steps. This simplifies
adding GA and local constant search learners, as well as parallelising
these learning steps.
- Extracts the non-incremental learn step into the class `prop_learnt`.
- Extracts the incremental learn step into the class
`incremental_prop_learnt`.
- Replaces `incremental_loop` and `non_incremental_loop` by single
`loop` function with configurable `learnt` learning step.