### PR TITLE
bug fix: grammar is not necessarily given for synth-fun

### DIFF
--- a/src/fastsynth/sygus_parser.cpp
+++ b/src/fastsynth/sygus_parser.cpp
@@ -149,6 +149,9 @@ void sygus_parsert::NTDef()
     return;
   }
 
+  if(peek()==OPEN)
+    next_token(); // symbol might be in another set of parenthesis
+
   if(next_token()!=SYMBOL)
   {
     error("NTDef must have a symbol");
@@ -173,6 +176,8 @@ void sygus_parsert::GTerm()
   switch(next_token())
   {
   case SYMBOL:
+  case NUMERAL:
+  case STRING_LITERAL:
     break;
 
   case OPEN:


### PR DESCRIPTION
SyGus format doesn't require that a grammar is given for the function being synthesised. 
The template may include double parenthesis
The template may include numerals or string literals. Not sure how these should be handled so I have replicated the symbol handling. 