### PR TITLE
introduce verbosity command line option

### DIFF
--- a/src/fastsynth/c_frontend.cpp
+++ b/src/fastsynth/c_frontend.cpp
@@ -141,6 +141,19 @@ int c_frontend(const cmdlinet &cmdline)
   console_message_handlert mh;
   messaget message(mh);
 
+  // this is our default verbosity
+  unsigned int v=messaget::M_STATISTICS;
+
+  if(cmdline.isset("verbosity"))
+  {
+    v=std::stol(
+        cmdline.get_value("verbosity"));;
+    if(v>10)
+      v=10;
+  }
+
+  mh.set_verbosity(v);
+
   register_language(new_ansi_c_language);
 
   config.set(cmdline);

--- a/src/fastsynth/fastsynth.cpp
+++ b/src/fastsynth/fastsynth.cpp
@@ -10,6 +10,7 @@
    "(max-program-size):" \
    "(incremental)" \
    "(simplifying-solver)" \
+   "(verbosity):" \
 
 int main(int argc, const char *argv[])
 {

--- a/src/fastsynth/sygus_frontend.cpp
+++ b/src/fastsynth/sygus_frontend.cpp
@@ -25,6 +25,19 @@ int sygus_frontend(const cmdlinet &cmdline)
   console_message_handlert message_handler;
   messaget message(message_handler);
 
+  // this is our default verbosity
+  unsigned int v=messaget::M_STATISTICS;
+
+  if(cmdline.isset("verbosity"))
+  {
+    v=std::stol(
+        cmdline.get_value("verbosity"));;
+    if(v>10)
+      v=10;
+  }
+
+  message_handler.set_verbosity(v);
+
   std::ifstream in(cmdline.args.front());
 
   if(!in)


### PR DESCRIPTION
Needed for testing, otherwise output is far too verbose