### PR TITLE
Set `message_handlert` in learners

### DIFF
--- a/src/fastsynth/cegis.cpp
+++ b/src/fastsynth/cegis.cpp
@@ -14,24 +14,26 @@
 decision_proceduret::resultt cegist::operator()(
   const problemt &problem)
 {
+  message_handlert &msg=get_message_handler();
+
   if(incremental_solving)
   {
     status() << "** incremental CEGIS" << eom;
     if(use_simp_solver)
     {
-      incremental_prop_learnt<satcheckt> learn(*this, ns, problem);
+      incremental_prop_learnt<satcheckt> learn(msg, ns, problem);
       return loop(problem, learn);
     }
     else
     {
-      incremental_prop_learnt<satcheck_no_simplifiert> inc(*this, ns, problem);
+      incremental_prop_learnt<satcheck_no_simplifiert> inc(msg, ns, problem);
       return loop(problem, inc);
     }
   }
   else
   {
     status() << "** non-incremental CEGIS" << eom;
-    prop_learnt learn(*this, ns, problem);
+    prop_learnt learn(msg, ns, problem);
     return loop(problem, learn);
   }
 }

--- a/src/fastsynth/composite_learn.cpp
+++ b/src/fastsynth/composite_learn.cpp
@@ -123,3 +123,9 @@ void composite_learnt::cancel()
 {
   for_each(begin(learners), end(learners), std::mem_fn(&learnt::cancel));
 }
+
+void composite_learnt::set_message_handler(message_handlert &message_handler)
+{
+  for(const std::unique_ptr<learnt> &message : learners)
+    message->set_message_handler(message_handler);
+}

--- a/src/fastsynth/composite_learn.h
+++ b/src/fastsynth/composite_learn.h
@@ -30,6 +30,9 @@ public:
   /// \see learnt::cancel()
   void cancel() override;
 
+  /// \see messaget::set_message_handler(message_handlert &)
+  void set_message_handler(message_handlert &_message_handler) override;
+
   /// Adds a new learner to the composite.
   /// \tparam T Type of the learner.
   /// \tparam argst Types of the learner's constructor arguments.

--- a/src/fastsynth/incremental_prop_learn.h
+++ b/src/fastsynth/incremental_prop_learn.h
@@ -15,9 +15,6 @@
 template <class satcheckt>
 class incremental_prop_learnt : public learnt
 {
-  /// Message handler for decision procedure messages.
-  messaget &msg;
-
   /// Namespace passed on to decision procedure.
   const namespacet &ns;
 
@@ -53,11 +50,11 @@ class incremental_prop_learnt : public learnt
 
 public:
   /// Creates an incremental learner.
-  /// \param msg \see msg incremental_prop_learnt::msg
+  /// \see messaget::messaget(message_handlert &)
   /// \param ns \see ns incremental_prop_learnt::ns
   /// \param problem \see incremental_prop_learnt::problem
   incremental_prop_learnt(
-    messaget &msg,
+    message_handlert &msg,
     const namespacet &ns,
     const cegist::problemt &problem);
 

--- a/src/fastsynth/incremental_prop_learn.inc
+++ b/src/fastsynth/incremental_prop_learn.inc
@@ -8,17 +8,17 @@
 
 template <class satcheckt>
 incremental_prop_learnt<satcheckt>::incremental_prop_learnt(
-  messaget &msg,
+  message_handlert &msg,
   const namespacet &ns,
   const cegist::problemt &problem)
-  : msg(msg),
-    ns(ns),
+  : ns(ns),
     problem(problem),
     synth_satcheck(new cancellable_solvert<satcheckt>()),
     synth_solver(new bv_pointerst(ns, *synth_satcheck)),
     program_size(1u),
     counterexample_counter(0u)
 {
+  set_message_handler(msg);
   init();
 }
 
@@ -26,8 +26,8 @@ template <class satcheckt>
 void incremental_prop_learnt<satcheckt>::init()
 {
   synth_encoding.program_size = program_size;
-  synth_satcheck->set_message_handler(msg.get_message_handler());
-  synth_solver->set_message_handler(msg.get_message_handler());
+  synth_satcheck->set_message_handler(get_message_handler());
+  synth_solver->set_message_handler(get_message_handler());
 
   generate_constraint(
     ns, get_message_handler(), problem, counterexamples,

--- a/src/fastsynth/prop_learn.cpp
+++ b/src/fastsynth/prop_learn.cpp
@@ -9,11 +9,12 @@
 #include <mutex>
 
 prop_learnt::prop_learnt(
-  messaget &msg,
+  message_handlert &msg,
   const namespacet &ns,
   const cegist::problemt &problem)
   : ns(ns), problem(problem), program_size(1u)
 {
+  set_message_handler(msg);
 }
 
 void prop_learnt::set_program_size(const size_t program_size)

--- a/src/fastsynth/prop_learn.h
+++ b/src/fastsynth/prop_learn.h
@@ -33,11 +33,11 @@ class prop_learnt : public learnt
 
 public:
   /// Creates a non-incremental learner.
-  /// \param msg \see msg prop_learnt::msg
+  /// \see messaget::messaget(message_handlert &)
   /// \param ns \see ns prop_learnt::ns
   /// \param problem \see prop_learnt::problem
   prop_learnt(
-    messaget &msg,
+    message_handlert &msg,
     const namespacet &ns,
     const cegist::problemt &problem);
 


### PR DESCRIPTION
`learnt` was changed to inherit from `messaget`. For this to work as
intended, their `set_message_handler` function must be invoked.