### PR TITLE
Make `synth_encodingt` configurable

### DIFF
--- a/src/fastsynth/Makefile
+++ b/src/fastsynth/Makefile
@@ -2,6 +2,7 @@ SRC = fastsynth.cpp verify_solver.cpp cegis.cpp \
       prop_learn.cpp incremental_prop_learn.cpp \
       composite_learn.cpp \
       synth_encoding.cpp verify_encoding.cpp \
+      synth_encoding_factory.cpp \
       synth_encoding_constraints.cpp \
       c_frontend.cpp sygus_frontend.cpp smt2_parser.cpp \
       sygus_parser.cpp local_search.cpp

--- a/src/fastsynth/incremental_prop_learn.h
+++ b/src/fastsynth/incremental_prop_learn.h
@@ -4,11 +4,9 @@
 #include <fastsynth/learn.h>
 #include <fastsynth/cegis.h>
 #include <fastsynth/cancellable_solver.h>
-#include <fastsynth/synth_encoding.h>
+#include <fastsynth/synth_encoding_factory.h>
 
 #include <solvers/sat/satcheck.h>
-
-#include <memory>
 
 /// Generates a constraint using synth_encodingt and solves it incrementally
 /// using a configurable propt instance.
@@ -21,6 +19,10 @@ class incremental_prop_learnt : public learnt
   /// Synthesis problem to solve.
   const cegist::problemt &problem;
 
+  /// Instantiates constraint generators to use for learning phase. This makes
+  /// e.g. the instruction set to use configurable.
+  const synth_encoding_factoryt synth_encoding_factory;
+
   /// Solver instance.
   std::unique_ptr<cancellable_solvert<satcheckt>> synth_satcheck;
 
@@ -28,7 +30,7 @@ class incremental_prop_learnt : public learnt
   std::unique_ptr<class bv_pointerst> synth_solver;
 
   /// Synthesis learn constraint generator.
-  synth_encodingt synth_encoding;
+  std::unique_ptr<synth_encodingt> synth_encoding;
 
   /// \see learnt::set_program_size(size_t)
   size_t program_size;
@@ -53,10 +55,14 @@ public:
   /// \see messaget::messaget(message_handlert &)
   /// \param ns \see ns incremental_prop_learnt::ns
   /// \param problem \see incremental_prop_learnt::problem
+  /// \param synth_encoding_factory
+  ///   \see incremental_prop_learnt::synth_encoding_factory
   incremental_prop_learnt(
     message_handlert &msg,
     const namespacet &ns,
-    const cegist::problemt &problem);
+    const cegist::problemt &problem,
+    synth_encoding_factoryt synth_encoding_factory =
+      default_synth_encoding_factory());
 
   /// \see learnt::set_program_size(size_t)
   void set_program_size(size_t program_size) override;

--- a/src/fastsynth/incremental_prop_learn.inc
+++ b/src/fastsynth/incremental_prop_learn.inc
@@ -1,4 +1,5 @@
 #include <fastsynth/incremental_prop_learn.h>
+#include <fastsynth/synth_encoding.h>
 #include <fastsynth/synth_encoding_constraints.h>
 
 #include <solvers/flattening/bv_pointers.h>
@@ -10,11 +11,14 @@ template <class satcheckt>
 incremental_prop_learnt<satcheckt>::incremental_prop_learnt(
   message_handlert &msg,
   const namespacet &ns,
-  const cegist::problemt &problem)
-  : ns(ns),
+  const cegist::problemt &problem,
+  const synth_encoding_factoryt synth_encoding_factory)
+  :ns(ns),
     problem(problem),
+    synth_encoding_factory(synth_encoding_factory),
     synth_satcheck(new cancellable_solvert<satcheckt>()),
     synth_solver(new bv_pointerst(ns, *synth_satcheck)),
+    synth_encoding(synth_encoding_factory()),
     program_size(1u),
     counterexample_counter(0u)
 {
@@ -25,13 +29,13 @@ incremental_prop_learnt<satcheckt>::incremental_prop_learnt(
 template <class satcheckt>
 void incremental_prop_learnt<satcheckt>::init()
 {
-  synth_encoding.program_size = program_size;
+  synth_encoding->program_size = program_size;
   synth_satcheck->set_message_handler(get_message_handler());
   synth_solver->set_message_handler(get_message_handler());
 
   generate_constraint(
     ns, get_message_handler(), problem, counterexamples,
-    synth_encoding, *synth_solver);
+    *synth_encoding, *synth_solver);
 
   freeze_expression_symbols();
 }
@@ -47,7 +51,7 @@ void incremental_prop_learnt<satcheckt>::set_program_size(
 
   synth_satcheck.reset(new cancellable_solvert<satcheckt>());
   synth_solver.reset(new bv_pointerst(ns, *synth_satcheck));
-  synth_encoding = synth_encodingt();
+  synth_encoding = synth_encoding_factory();
   init();
 }
 
@@ -62,7 +66,7 @@ template <class satcheckt>
 std::map<symbol_exprt, exprt>
 incremental_prop_learnt<satcheckt>::get_expressions() const
 {
-  return synth_encoding.get_expressions(*synth_solver);
+  return synth_encoding->get_expressions(*synth_solver);
 }
 
 template <class satcheckt>
@@ -71,12 +75,12 @@ void incremental_prop_learnt<satcheckt>::add(
 {
   counterexamples.emplace_back(counterexample);
 
-  synth_encoding.constraints.clear();
+  synth_encoding->constraints.clear();
 
-  synth_encoding.suffix = "$ce" + std::to_string(counterexample_counter);
+  synth_encoding->suffix = "$ce" + std::to_string(counterexample_counter);
 
-  add_counterexample(ns, get_message_handler(), counterexample, synth_encoding, *synth_solver);
-  add_problem(ns, get_message_handler(), problem, synth_encoding, *synth_solver);
+  add_counterexample(ns, get_message_handler(), counterexample, *synth_encoding, *synth_solver);
+  add_problem(ns, get_message_handler(), problem, *synth_encoding, *synth_solver);
 
   freeze_expression_symbols();
   counterexample_counter++;

--- a/src/fastsynth/prop_learn.h
+++ b/src/fastsynth/prop_learn.h
@@ -4,6 +4,7 @@
 #include <fastsynth/learn.h>
 #include <fastsynth/cegis.h>
 #include <fastsynth/cancellable_solver.h>
+#include <fastsynth/synth_encoding_factory.h>
 
 #include <solvers/sat/satcheck.h>
 
@@ -18,6 +19,10 @@ class prop_learnt : public learnt
 
   /// Synthesis problem to solve.
   const cegist::problemt &problem;
+
+  /// Instantiates constraint generators to use for learning phase. This makes
+  /// e.g. the instruction set to use configurable.
+  const synth_encoding_factoryt synth_encoding_factory;
 
   /// \see learnt::set_program_size(size_t)
   size_t program_size;
@@ -36,10 +41,13 @@ public:
   /// \see messaget::messaget(message_handlert &)
   /// \param ns \see ns prop_learnt::ns
   /// \param problem \see prop_learnt::problem
+  /// \param synth_encoding_factory \see prop_learnt::synth_encoding_factory
   prop_learnt(
     message_handlert &msg,
     const namespacet &ns,
-    const cegist::problemt &problem);
+    const cegist::problemt &problem,
+    synth_encoding_factoryt synth_encoding_factory =
+      default_synth_encoding_factory());
 
   /// \see learnt::set_program_size(size_t)
   void set_program_size(size_t program_size) override;

--- a/src/fastsynth/synth_encoding_factory.cpp
+++ b/src/fastsynth/synth_encoding_factory.cpp
@@ -1,0 +1,8 @@
+#include <fastsynth/synth_encoding_factory.h>
+#include <fastsynth/synth_encoding.h>
+
+synth_encoding_factoryt default_synth_encoding_factory()
+{
+  return
+    []() { return std::unique_ptr<synth_encodingt>(new synth_encodingt()); };
+}

--- a/src/fastsynth/synth_encoding_factory.h
+++ b/src/fastsynth/synth_encoding_factory.h
@@ -1,0 +1,14 @@
+#ifndef CPROVER_FASTSYNTH_SYNTH_ENCODING_FACTORY_H_
+#define CPROVER_FASTSYNTH_SYNTH_ENCODING_FACTORY_H_
+
+#include <functional>
+#include <memory>
+
+/// Factory class used to instantiate configurable synth_encodingt instances.
+typedef std::function<std::unique_ptr<class synth_encodingt>()>
+  synth_encoding_factoryt;
+
+/// Factory for the default synth_encodingt.
+synth_encoding_factoryt default_synth_encoding_factory();
+
+#endif /* CPROVER_FASTSYNTH_SYNTH_ENCODING_FACTORY_H_ */


### PR DESCRIPTION
Provide a factory as parameter to both `prop_learnt` and
`incremental_prop_learnt` allowing to construct configurable
`synth_encodingt` instances.