### PR TITLE
renamed let variables must be added to problem free variables

### DIFF
--- a/src/fastsynth/sygus_frontend.cpp
+++ b/src/fastsynth/sygus_frontend.cpp
@@ -79,6 +79,9 @@ int sygus_frontend(const cmdlinet &cmdline)
   for(const auto &v : parser.variable_map)
     problem.free_variables.insert(symbol_exprt(v.first, v.second));
 
+  for(const auto &v: parser.full_let_variable_map)
+    problem.free_variables.insert(symbol_exprt(v.first, v.second));
+
   for(auto &c : problem.constraints)
     parser.expand_function_applications(c);
 

--- a/src/fastsynth/sygus_parser.cpp
+++ b/src/fastsynth/sygus_parser.cpp
@@ -87,6 +87,7 @@ exprt::operandst sygus_parsert::operands()
 let_exprt sygus_parsert::let_expression(bool first_in_chain)
 {
   let_exprt result;
+  let_counter++;
 
   if(peek()!=OPEN && !first_in_chain)
   {
@@ -122,10 +123,12 @@ let_exprt sygus_parsert::let_expression(bool first_in_chain)
     // end of the let, but that's hard with recursion
     irep_idt old_id=result.symbol().get_identifier();
     irep_idt new_id=id2string(old_id)+
-                    '#'+std::to_string(id_counter++);
+                    '#'+std::to_string(id_counter++)+
+                    'L'+std::to_string(let_counter++);
 
     result.symbol().set_identifier(new_id);
     let_variable_map[new_id]=result.value().type();
+    full_let_variable_map[new_id]=result.value().type();
     renaming_map[old_id]=new_id;
 
     if(peek()!=CLOSE) // we are still in a chain of bindings

--- a/src/fastsynth/sygus_parser.h
+++ b/src/fastsynth/sygus_parser.h
@@ -10,7 +10,8 @@ class sygus_parsert:public smt2_tokenizert
 public:
   explicit sygus_parsert(std::istream &_in):
     smt2_tokenizert(_in),
-    id_counter(0)
+    id_counter(0),
+    let_counter(0)
   {
   }
 
@@ -50,8 +51,10 @@ public:
   variable_mapt variable_map;
   variable_mapt local_variable_map;
   variable_mapt let_variable_map;
+  variable_mapt full_let_variable_map;
 
   unsigned id_counter;
+  unsigned let_counter;
   using renaming_mapt=std::map<irep_idt, irep_idt>;
   renaming_mapt renaming_map;
 


### PR DESCRIPTION
Without this, the verifier can't find the assignments to the renamed variables in the counterexamples