### PR TITLE
Fix clang compiler error

### DIFF
--- a/src/fastsynth/local_cegis.cpp
+++ b/src/fastsynth/local_cegis.cpp
@@ -11,8 +11,6 @@
 
 #include <iterator>
 
-#include <iterator>
-
 local_cegist::local_cegist(
   const namespacet &ns,
   verifyt &verify,
@@ -209,7 +207,7 @@ local_cegist::create_learner(synth_encoding_baset &synth_encoding)
       new solver_learnt(ns, problem, synth_encoding, msg));
     learn->use_smt = use_smt;
     learn->logic = logic;
-    return learn;
+    return move(learn);
   }
 }
 


### PR DESCRIPTION
RVO is not triggered on clang in CI. Adding explicit std::move.