### PR TITLE
remove std::move in return statement

### DIFF
--- a/src/fastsynth/bool_synth_encoding.cpp
+++ b/src/fastsynth/bool_synth_encoding.cpp
@@ -435,7 +435,7 @@ exprt bool_synth_encodingt::operator()(const exprt &expr)
     exprt tmp{expr};
     irep_idt identifier = id2string(tmp.get(ID_identifier)) + suffix;
     tmp.set(ID_identifier, identifier);
-    return std::move(tmp);
+    return tmp;
   }
   else
   {


### PR DESCRIPTION
using std::move in a return statement triggers warnings on clang:

bool_synth_encoding.cpp:438:12: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
    return std::move(tmp);

