### PR TITLE
Update BitVec parsing to align with SyGuS-IF 2.0

### DIFF
--- a/src/fastsynth/sygus_parser.cpp
+++ b/src/fastsynth/sygus_parser.cpp
@@ -1098,8 +1098,27 @@ typet sygus_parsert::sort()
   case OPEN:
     if(next_token()!=SYMBOL)
       throw error("expected symbol after '(' in a sort");
+    if(buffer=="_")
+    {
+      // SyGuS-IF v2.0 now matches smt-lib syntax
+      if(next_token() != SYMBOL)
+        throw error("expected symbol after '_' in a sort");
 
-    if(buffer=="BitVec")
+      if(buffer == "BitVec")
+      {
+        if(next_token() != NUMERAL)
+          throw error("expected numeral as bit-width");
+
+        auto width = std::stoll(buffer);
+
+        // eat the ')'
+        if(next_token() != CLOSE)
+          throw error("expected ')' at end of sort");
+
+        return unsignedbv_typet(width);
+      }
+    }
+    else if(buffer=="BitVec")
     {
       // this has slightly different symtax compared to SMT-LIB2
       if(next_token()!=NUMERAL)


### PR DESCRIPTION
SyGuS-IF 2.0 now uses (_ BitVec) format. I've left the old parsing in for now, but we can eventually delete this and migrate all our regression tests and benchmarks forward to the new format