### PR TITLE
add frontend back to cmdline options

### DIFF
--- a/src/fastsynth/frontend_util.cpp
+++ b/src/fastsynth/frontend_util.cpp
@@ -172,6 +172,7 @@ void set_cegis_cmdline_properties(const cmdlinet &cmdline, cegist &cegis)
   cegis.enable_bitwise = !cmdline.isset("no-bitwise");
   cegis.use_smt = cmdline.isset("smt");
   cegis.enable_division = cmdline.isset("enable-division");
+  cegis.use_local_search=cmdline.isset("local-search");
   cegis.logic = DEFAULT_CEGIS_LOGIC;
 }
 


### PR DESCRIPTION
Putting back the local search cmdline option, it was removed in this commit:
https://github.com/kroening/fastsynth/commit/7135297807f7f9877346265c1f1c3fa678abe889
