### PR TITLE
Generalise SyGuS grammar ignoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,14 @@
 .settings
 .clang-format
 src/fastsynth/fastsynth
+tasks.json
+*.code-workspace
 *.d
+*.idb
+*.ilk
 *.o
+*.obj
 *.out
+*.pdb
 *.log
 *.exe

--- a/regression/fastsynth-sygus/sygus-v2/sygus-v2.sl
+++ b/regression/fastsynth-sygus/sygus-v2/sygus-v2.sl
@@ -1,0 +1,13 @@
+(set-logic LIA)
+
+(synth-fun fb () Int
+    ((Start Int))
+    ((Start Int ((Constant Int)))))
+
+(synth-fun fc () Int
+    ((Start Int))
+    ((Start Int ((Constant Int)))))
+
+(constraint (= (fc) (+ (fb) 10)))
+
+(check-synth)

--- a/regression/fastsynth-sygus/sygus-v2/test.desc
+++ b/regression/fastsynth-sygus/sygus-v2/test.desc
@@ -1,0 +1,9 @@
+CORE
+sygus-v2.sl
+
+^EXIT=0$
+^SIGNAL=0$
+^Result: fb -> -10$
+^Result: fc -> 0$
+--
+^warning: ignoring

--- a/src/fastsynth/sygus_parser.cpp
+++ b/src/fastsynth/sygus_parser.cpp
@@ -969,16 +969,27 @@ void sygus_parsert::generate_invariant_constraints()
 
 void sygus_parsert::NTDef_seq()
 {
-  // it is not necessary to give a syntactic template
-  if(smt2_tokenizer.peek()!=smt2_tokenizert::OPEN)
-    return;
-
-  while(smt2_tokenizer.peek()!=smt2_tokenizert::CLOSE)
+  uint8_t openCount = 0u;
+  while(smt2_tokenizer.peek()!=smt2_tokenizert::CLOSE || openCount)
   {
-    NTDef();
+    switch(smt2_tokenizer.next_token())
+    {
+      case smt2_tokenizert::OPEN:
+      ++openCount;
+      break;
+      case smt2_tokenizert::CLOSE:
+      --openCount;
+      break;
+      case smt2_tokenizert::END_OF_FILE:
+      case smt2_tokenizert::KEYWORD:
+      case smt2_tokenizert::NONE:
+      case smt2_tokenizert::NUMERAL:
+      case smt2_tokenizert::STRING_LITERAL:
+      case smt2_tokenizert::SYMBOL:
+      // Ignore grammar.
+      break;
+    }
   }
-
-  smt2_tokenizer.next_token(); // eat the ')'
 }
 
 void sygus_parsert::GTerm_seq()

--- a/src/fastsynth/sygus_parser.h
+++ b/src/fastsynth/sygus_parser.h
@@ -107,6 +107,7 @@ protected:
   exprt cast_bv_to_unsigned(exprt &expr);
   void check_bitvector_operands(exprt &expr);
 
+  /// Helper to consume and ignore SyGuS V2 grammars.
   void NTDef_seq();
   void GTerm_seq();
   void NTDef();


### PR DESCRIPTION
Expand `NTDef_seq` to accept any grammar content within a `synth-fun`. Closes https://github.com/kroening/fastsynth/issues/92.